### PR TITLE
Pinning color-string at 0.4.x to prevent breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "color": "*",
-    "color-string": "*"
+    "color-string": "^0.4.0"
   },
   "main": "index"
 }


### PR DESCRIPTION
@stoyan — this will protect `csscolormin` from breaking changes released in `color-string@1.0.0`.

Fixes #2 
