### PR TITLE
Upgrade to the latest version of color*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+
+sudo: false
+
+node_js: 'lts/*'
+
+script:
+- npm test

--- a/index.js
+++ b/index.js
@@ -1,47 +1,43 @@
 var color = require("color");
 var string = require("color-string");
+var names = require("color-name");
+
+var reverseNames = {};
+for (var key in names) {
+  if (names.hasOwnProperty(key)) {
+    reverseNames[names[key]] = key;
+  }
+}
 
 exports.min = function min(c) {
 
-  if (Array.isArray(c)) {
-    var colour = color({
-      r: c[0],
-      g: c[1],
-      b: c[2],
-    });
-    if ('3' in c) {
-      colour.alpha(c[3]);
-    }
-  } else {
-    var colour = color(c);
-  }
-  var alpha = colour.values.alpha;
-  var rgb = colour.values.rgb;
+  var colour = color(c);
+  var alpha = colour.alpha() || 0;
+  var rgb = colour.rgb().array();
 
   if (rgb[0] === 0 && rgb[1] === 0 && rgb[2] === 0 && alpha === 0) {
     return 'transparent';
   }
 
   if (alpha !== 1) {
-    // no choice, gotta be rgba
-    if (alpha < 1) {
-      alpha = String(alpha).replace('0.', '.');
-    }
-    return string
-      .rgbaString(rgb, alpha)
+    return string.to.rgb(rgb, alpha)
       .replace(/ /g, '')
+      .replace('0.', '.')
       .toLowerCase();
   }
 
   // hex, short hex, or keyword
-  var hex = colour.hexString();
+  var hex = colour.hex();
+  var word = reverseNames[colour.rgb().color];
+
   if (hex[1] === hex[2] && hex[3] === hex[4] && hex[5] === hex[6]) {
     hex = ['#', hex[1], hex[3], hex[5]].join('');
   }
-  var word = colour.keyword();
+
   if (!word || hex.length < word.length) {
     return hex.toLowerCase();
   }
+
   return word.toLowerCase();
 };
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "type": "git",
     "url": "git://github.com/stoyan/csscolormin.git"
   },
+  "scripts": {
+    "test": "node test/test.js"
+  },
   "dependencies": {
-    "color": "*",
-    "color-string": "^0.4.0"
+    "color": "2.0.0"
   },
   "main": "index"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,6 @@ assert.equal(min("goldenrod"), "#daa520");
 assert.equal(min([255, 0,   0, 1]), "red");
 assert.equal(min([0, 0, 0, 0]), "transparent");
 assert.equal(min([255, 127, 0]), "#ff7f00");
-assert.equal(min({r: 0, g: 0, b: 255, a: 0.5}), "rgba(0,0,255,.5)");
+assert.equal(min({r: 0, g: 0, b: 255, alpha: 0.5}), "rgba(0,0,255,.5)");
 
 console.log('all good!');


### PR DESCRIPTION
* Adds Travis build
* Upgrade to the latest version of color* and fix the version in `package.json`


Otherwise `csscolormin` is failing:

```
/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/csscolormin/index.js:18
  var alpha = colour.values.alpha;
                           ^
TypeError: Cannot read property 'alpha' of undefined
    at min (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/csscolormin/index.js:18:28)
    at Object.process (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/cssshrink/lib/visitors/color-functions.js:35:20)
    at tree (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:7:20)
    at tree (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:15:13)
    at tree (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:15:13)
    at tree (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:15:13)
    at tree (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:15:13)
    at tree (/home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:15:13)
    at /home/travis/build/asciidoctor/asciidoctor-stylesheet-factory/node_modules/gonzales-ast/lib/traverse.js:24:11
    at Array.forEach (native)
```